### PR TITLE
Surface areas

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,6 +1,7 @@
 numpy
 torch
 scipy
+scikit-image
 matplotlib
 tifffile
 myst_parser

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -14,3 +14,4 @@ pytest-runner==5.2
 numpy>=1.24.2
 tifffile==2023.2.3
 myst-parser==0.18.1
+scikit-image>=0.20.0

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -15,3 +15,4 @@ numpy>=1.24.2
 tifffile==2023.2.3
 myst-parser==0.18.1
 scikit-image>=0.20.0
+scipy>=1.3

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ with open('README.md') as readme_file:
 with open('HISTORY.md') as history_file:
     history = history_file.read()
 
-requirements = ['Click>=7.0', 'numpy>=1.0', 'matplotlib>=3.4', 'tifffile>=2023.2.3']
+requirements = ['Click>=7.0', 'numpy>=1.0', 'matplotlib>=3.4', 'tifffile>=2023.2.3', 'scikit-image>=0.20.0']
 
 setup_requirements = ['pytest-runner', ]
 

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,14 @@ with open('README.md') as readme_file:
 with open('HISTORY.md') as history_file:
     history = history_file.read()
 
-requirements = ['Click>=7.0', 'numpy>=1.0', 'matplotlib>=3.4', 'tifffile>=2023.2.3', 'scikit-image>=0.20.0']
+requirements = [
+    'Click>=7.0',
+    'numpy>=1.0',
+    'matplotlib>=3.4',
+    'tifffile>=2023.2.3',
+    'scikit-image>=0.20.0',
+    'scipy>=1.3'
+]
 
 setup_requirements = ['pytest-runner', ]
 

--- a/taufactor/metrics.py
+++ b/taufactor/metrics.py
@@ -236,6 +236,8 @@ def extract_through_feature(array, grayscale_value, axis, periodic=[False,False,
 
     # Compute volume fraction of given grayscale value
     vol_phase = volume_fraction(array, phases={'1': grayscale_value})['1']
+    if vol_phase == 0:
+        return 0, 0
 
     # Define a list of connectivities to loop over
     connectivities_to_loop_over = [connectivity] if connectivity else range(1, 4)

--- a/taufactor/metrics.py
+++ b/taufactor/metrics.py
@@ -57,7 +57,7 @@ def crop_area_of_interest_numpy(array, labels):
                       max(min_idx[2]-3, 0):min(max_idx[2]+4, array.shape[2])]
     return sub_array
 
-def gaussian_kernel_3d_torch(size=3, sigma=1.0, device):
+def gaussian_kernel_3d_torch(device, size=3, sigma=1.0):
     """Creates a 3D Gaussian kernel using PyTorch"""
     ax = torch.linspace(-(size // 2), size // 2, size)
     xx, yy, zz = torch.meshgrid(ax, ax, ax, indexing="ij")

--- a/taufactor/metrics.py
+++ b/taufactor/metrics.py
@@ -4,7 +4,7 @@ import torch.nn.functional as F
 
 from scipy.ndimage import label, generate_binary_structure
 
-def volume_fraction(img, phases={}, device=torch.device('cuda')):
+def volume_fraction(img, phases={}):
     """
     Calculates volume fractions of phases in an image
     :param img: segmented input image with n phases
@@ -13,7 +13,7 @@ def volume_fraction(img, phases={}, device=torch.device('cuda')):
     """
 
     if type(img) is not type(torch.tensor(1)):
-        img = torch.tensor(img, device=device)
+        img = torch.tensor(img)
 
     if phases=={}:
         volume = torch.numel(img)

--- a/taufactor/taufactor.py
+++ b/taufactor/taufactor.py
@@ -7,6 +7,7 @@ try:
 except ImportError:
     raise ImportError("Pytorch is required to use this package. Please install pytorch and try again. More information about TauFactor's requirements can be found at https://taufactor.readthedocs.io/en/latest/")
 import warnings
+from .metrics import extract_through_feature
 
 class BaseSolver:
     def __init__(self, img, bc=(-0.5, 0.5), device=torch.device('cuda')):
@@ -89,7 +90,9 @@ class BaseSolver:
         fl = torch.sum(vert_flux, (0, 2, 3))
         err = (fl.max() - fl.min())/(fl.max())
         if fl.min() == 0:
-            return 'zero_flux', torch.mean(fl), err
+            _ , frac = extract_through_feature(self.cpu_img[0], 1, 'x')
+            if frac == 0:
+                return 'zero_flux', torch.mean(fl), err
         if err < conv_crit or torch.isnan(err).item():
             return True, torch.mean(fl), err
         return False, torch.mean(fl), err

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -1,0 +1,179 @@
+#!/usr/bin/env python
+
+"""Tests for `taufactor` package."""
+
+from taufactor.metrics import volume_fraction, specific_surface_area, triple_phase_boundary
+from tests.utils import *
+import numpy as np
+
+
+# Volume fraction
+
+def test_volume_fraction_on_uniform_block():
+    """Run volume fraction on uniform block"""
+    l = 20
+    img = np.ones([l, l, l]).reshape(1, l, l, l)
+    vf = volume_fraction(img)['1']
+
+    assert np.around(vf, decimals=5) == 1.0
+
+
+def test_volume_fraction_on_empty_block():
+    """Run volume fraction on empty block"""
+    l = 20
+    img = np.zeros([l, l, l]).reshape(1, l, l, l)
+    vf = volume_fraction(img)['0']
+
+    assert np.around(vf, decimals=5) == 1.0
+
+
+def test_volume_fraction_on_checkerboard():
+    """Run volume fraction on checkerboard block"""
+    l = 20
+    img = generate_checkerboard(l)
+    vf = volume_fraction(img, phases={'zeros': 0, 'ones': 1})
+
+    assert (vf['zeros'], vf['ones']) == (0.5, 0.5)
+
+
+def test_volume_fraction_on_strip_of_ones():
+    """Run volume fraction on strip of ones"""
+    l = 20
+    img = np.zeros([l, l, l])
+    t = 10
+    img[:, 0:t, 0:t] = 1
+    vf = volume_fraction(img, phases={'zeros': 0, 'ones': 1})
+
+    assert (vf['zeros'], vf['ones']) == (0.75, 0.25)
+
+
+def test_volume_fraction_on_multi_cubes():
+    """Run surface area on multiple cubes"""
+    l = 20
+    img = np.zeros([l, l, l])
+    img[0:10, 0:10, 0:5] = 1
+    img[5:-5, 5:-5, 5:-5] = 2
+    img[0:10, 0:10, 15:] = 1
+    img[10:, 10:, 15:] = 3
+    vf = volume_fraction(img)
+    sum = vf['0'] + vf['1'] + vf['2'] + vf['3']
+
+    assert (vf['1'], vf['2'], vf['3'], sum) == (0.125, 0.125, 0.0625, 1.0)
+
+# Surface area
+
+def test_surface_area_on_uniform_block():
+    """Run surface area on uniform block"""
+    l = 20
+    img = np.ones([l, l, l])
+    sa_f = specific_surface_area(img, method='face_counting')['1']
+    sa_g = specific_surface_area(img, method='gradient')['1']
+    # Marchin cubes will not work unless there are non-uniform values
+    # sa_m = specific_surface_area(img, method='marching_cubes')
+
+    assert (sa_f, sa_g) == (0, 0)
+
+
+def test_surface_area_on_floating_cube():
+    """Run surface area on floating cube"""
+    l = 20
+    img = np.zeros([l, l, l])
+    x1, x2 = 5, 15
+    img[x1:x2, x1:x2, x1:x2] = 1
+    sa_f = specific_surface_area(img, method='face_counting')['1']
+    sa_m = specific_surface_area(img, method='marching_cubes', smoothing=False, device='cpu')['1']
+    sa_g = specific_surface_area(img, method='gradient', smoothing=False)['1']
+
+    # All six sides should be taken into account
+    # True value is 0.075
+    assert (np.around(sa_f, 5), np.around(sa_m, 5), np.around(sa_g, 5)) == (0.075, 0.07051, 0.07085)
+
+
+def test_surface_area_on_corner_cube():
+    """Run surface area on corner cube"""
+    l = 20
+    img = np.zeros([l, l, l])
+    img[0:10, 0:10, 0:10] = 1
+    sa_f = specific_surface_area(img, method='face_counting')['1']
+
+    # Only three inner sides should be taken into account
+    # True value is 0.0375
+    assert np.around(sa_f, 5) == 0.0375
+
+
+def test_surface_area_on_sphere():
+    """Run surface area on sphere"""
+    l = 20
+    img = np.zeros([l, l, l])
+    radius = l*0.5-3
+    x, y, z = np.ogrid[:l, :l, :l]
+    distance_squared = (x - l/2 + 0.5)**2 + (y - l/2 + 0.5)**2 + (z - l/2 + 0.5)**2
+    mask = distance_squared <= radius**2
+    img[mask] = 1
+    a_theo = 4*np.pi*radius**2/img.size
+    sa_f = np.abs(specific_surface_area(img, method='face_counting')['1']-a_theo)/a_theo*100
+    sa_m = np.abs(specific_surface_area(img, method='marching_cubes', device='cpu')['1']-a_theo)/a_theo*100
+    sa_g = np.abs(specific_surface_area(img, method='gradient')['1']-a_theo)/a_theo*100
+
+    # Relative errors should be
+    # - face_counting: 52.01 %,
+    # - marching_cubes: 0.82 %,
+    # - gradient:       0.95 %
+    assert (np.around(sa_f, 2), np.around(sa_m, 2), np.around(sa_g, 2)) == (52.01, 0.82, 0.95)
+
+
+def test_surface_area_on_multi_cubes():
+    """Run surface area on multiple cubes"""
+    l = 20
+    img = np.zeros([l, l, l])
+    img[0:10, 0:10, 0:5] = 1
+    img[5:-5, 5:-5, 5:-5] = 2
+    img[0:10, 0:10, 15:] = 1
+    img[10:, 10:, 15:] = 3
+    sa_f = specific_surface_area(img, method='face_counting')
+    sa_m = specific_surface_area(img, method='marching_cubes', smoothing=False, device='cpu')
+    sa_g = specific_surface_area(img, method='gradient', smoothing=False)
+    results = []
+    for sa in [sa_f, sa_m, sa_g]:
+        for phase in ['1', '2', '3']:
+            results.append(np.around(sa[phase], 4))
+    # All six sides should be taken into account
+    # True value is 0.075
+    reference = [0.0500, 0.0750, 0.0250, \
+                 0.0422, 0.0705, 0.0211, \
+                 0.0482, 0.0709, 0.0241]
+    assert results == reference
+
+
+def test_tpb_2d():
+    """Run tpb on 3x3"""
+    l = 3
+    img = np.zeros([l, l])
+    img[0] = 1
+    img[:, 0] = 2
+    tpb = triple_phase_boundary(img)
+    assert tpb == 0.25
+
+
+def test_tpb_3d_corners():
+    """Run tpb on 2x2"""
+
+    l = 2
+    img = np.zeros([l, l, l])
+    img[0, 0, 0] = 1
+    img[1, 1, 1] = 1
+    img[0, 1, 1] = 2
+    img[1, 0, 0] = 2
+    tpb = triple_phase_boundary(img)
+    assert tpb == 1
+
+
+def test_tpb_3d_corners():
+    """Run tpb on 2x2 corners"""
+
+    l = 2
+    img = np.zeros([l, l, l])
+    img[0] = 1
+    img[:, 0] = 2
+    tpb = triple_phase_boundary(img)
+    assert tpb == 1/3

--- a/tests/test_taufactor.py
+++ b/tests/test_taufactor.py
@@ -125,7 +125,7 @@ def test_volume_fraction_on_uniform_block():
     """Run volume fraction on uniform block"""
     l = 20
     img = np.ones([l, l, l]).reshape(1, l, l, l)
-    vf = volume_fraction(img)
+    vf = volume_fraction(img)['1']
 
     assert np.around(vf, decimals=5) == 1.0
 
@@ -134,7 +134,7 @@ def test_volume_fraction_on_empty_block():
     """Run volume fraction on empty block"""
     l = 20
     img = np.zeros([l, l, l]).reshape(1, l, l, l)
-    vf = volume_fraction(img)
+    vf = volume_fraction(img)['0']
 
     assert np.around(vf, decimals=5) == 1.0
 
@@ -143,9 +143,9 @@ def test_volume_fraction_on_checkerboard():
     """Run volume fraction on checkerboard block"""
     l = 20
     img = generate_checkerboard(l)
-    vf = volume_fraction(img)
+    vf = volume_fraction(img, phases={'zeros': 0, 'ones': 1})
 
-    assert vf == [0.5, 0.5]
+    assert (vf['zeros'], vf['ones']) == [0.5, 0.5]
 
 
 def test_volume_fraction_on_strip_of_ones():

--- a/tests/test_taufactor.py
+++ b/tests/test_taufactor.py
@@ -2,16 +2,12 @@
 
 """Tests for `taufactor` package."""
 
-import pytest
 import taufactor as tau
-from taufactor.metrics import volume_fraction, surface_area, triple_phase_boundary
 import torch as pt
-from tests.utils import *
 import numpy as np
-import matplotlib.pyplot as plt
-import torch
-#  Testing the main solver
 
+
+#  Testing the main solver
 
 def test_solver_on_uniform_block():
     """Run solver on a block of ones."""
@@ -74,8 +70,9 @@ def test_solver_on_slanted_strip_of_ones():
     S = tau.Solver(img, device=pt.device('cpu'))
     S.solve()
     assert np.around(S.tau, decimals=5) == 4
-#  Testing the periodic solver
 
+
+#  Testing the periodic solver
 
 def test_deadend():
     """Test deadend pore"""
@@ -117,146 +114,8 @@ def test_periodic_solver_on_strip_of_ones():
     S.solve()
     assert np.around(S.tau, decimals=5) == 1
 
-# Testing the metrics
-# Volume fraction
 
-
-def test_volume_fraction_on_uniform_block():
-    """Run volume fraction on uniform block"""
-    l = 20
-    img = np.ones([l, l, l]).reshape(1, l, l, l)
-    vf = volume_fraction(img)['1']
-
-    assert np.around(vf, decimals=5) == 1.0
-
-
-def test_volume_fraction_on_empty_block():
-    """Run volume fraction on empty block"""
-    l = 20
-    img = np.zeros([l, l, l]).reshape(1, l, l, l)
-    vf = volume_fraction(img)['0']
-
-    assert np.around(vf, decimals=5) == 1.0
-
-
-def test_volume_fraction_on_checkerboard():
-    """Run volume fraction on checkerboard block"""
-    l = 20
-    img = generate_checkerboard(l)
-    vf = volume_fraction(img, phases={'zeros': 0, 'ones': 1})
-
-    assert (vf['zeros'], vf['ones']) == (0.5, 0.5)
-
-
-def test_volume_fraction_on_strip_of_ones():
-    """Run volume fraction on strip of ones"""
-    l = 20
-    img = np.zeros([l, l, l])
-    t = 10
-    img[:, 0:t, 0:t] = 1
-    vf = volume_fraction(img, phases={'zeros': 0, 'ones': 1})
-
-    assert (vf['zeros'], vf['ones']) == (0.75, 0.25)
-
-# Surface area
-
-
-def test_surface_area_on_uniform_block():
-    """Run surface area on uniform block"""
-    l = 20
-    img = np.ones([l, l, l])
-    sa = surface_area(img, phases=[1])
-
-    assert sa == 0
-
-
-def test_surface_area_on_empty_block():
-    """Run surface area on empty block"""
-    l = 20
-    img = np.zeros([l, l, l])
-    sa = surface_area(img, phases=[0])
-
-    assert sa == 0
-
-def test_surface_area_on_checkerboard():
-    """Run surface area on checkerboard block"""
-    l = 50
-    img = generate_checkerboard(l)
-    sa = surface_area(img, phases=[0, 1])
-
-    assert sa == 1
-
-
-def test_surface_area_on_strip_of_ones():
-    """Run surface area on single one in small 2x2z2 cube"""
-    l = 2
-    img = np.zeros([l, l, l])
-    t = 1
-    img[0, 0, 0] = 1
-    sa = surface_area(img, phases=[0, 1])
-
-    assert sa == 0.25
-
-
-def test_surface_area_on_non_periodic_2d():
-    """Run surface area on a pair of one in small 3x3 square"""
-    img = np.array([[0, 0, 0], [1, 1, 0], [0, 0, 0]])
-    sa = surface_area(img, phases=[0, 1])
-
-    assert sa == 5/12
-
-
-def test_surface_area_on_periodic_2d():
-    """Run surface area on a pair of one in small 3x3 square"""
-    img = np.array([[0, 0, 0], [1, 1, 0], [0, 0, 0]])
-    sa = surface_area(img, phases=[0, 1], periodic=[0, 1])
-
-    assert sa == 6/18
-
-
-def test_surface_area_interfactial_3ph():
-    """Run surface area 3 phases """
-    l = 3
-    img = np.zeros([l, l, l])
-    img[1] = 1
-    img[2] = 2
-    sa = surface_area(img, phases=[1, 2])
-    assert sa == 1/6
-
-
-def test_tpb_2d():
-    """Run tpb on 3x3"""
-    l = 3
-    img = np.zeros([l, l])
-    img[0] = 1
-    img[:, 0] = 2
-    tpb = triple_phase_boundary(img)
-    assert tpb == 0.25
-
-
-def test_tpb_3d_corners():
-    """Run tpb on 2x2"""
-
-    l = 2
-    img = np.zeros([l, l, l])
-    img[0, 0, 0] = 1
-    img[1, 1, 1] = 1
-    img[0, 1, 1] = 2
-    img[1, 0, 0] = 2
-    tpb = triple_phase_boundary(img)
-    assert tpb == 1
-
-
-def test_tpb_3d_corners():
-    """Run tpb on 2x2 corners"""
-
-    l = 2
-    img = np.zeros([l, l, l])
-    img[0] = 1
-    img[:, 0] = 2
-    tpb = triple_phase_boundary(img)
-    assert tpb == 1/3
-
+#  Testing the multiphase solver
 
 def test_multiphase_and_solver_agree():
     """test mph and solver agree when Ds are the same"""
@@ -341,6 +200,8 @@ def test_mphsolver_on_strip_of_ones_and_twos_and_threes():
     S.solve()
     assert np.around(S.tau, 4) == 1
 
+
+#  Testing the tau_e solver
 
 def test_taue_deadend():
     """Run solver on a deadend strip of ones"""

--- a/tests/test_taufactor.py
+++ b/tests/test_taufactor.py
@@ -145,7 +145,7 @@ def test_volume_fraction_on_checkerboard():
     img = generate_checkerboard(l)
     vf = volume_fraction(img, phases={'zeros': 0, 'ones': 1})
 
-    assert (vf['zeros'], vf['ones']) == [0.5, 0.5]
+    assert (vf['zeros'], vf['ones']) == (0.5, 0.5)
 
 
 def test_volume_fraction_on_strip_of_ones():


### PR DESCRIPTION
Add more elaborate surface area computation.
`specific_surface_area()` now takes` method=` as input which can be

- `'gradient'` for fast phase-field approach
- `'face_counting'` for face counting or
- `'marching_cubes'` for marching cubes method

The first method is fully compatible with anisotropic voxels and roughly by a factor of ten faster than marching cubes.
This branch is based on pull request #106 and should be merged afterwards.
This branch solves issue #93.