### PR TITLE
Fix convergence issue and add gpu/cpu stats

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -4,6 +4,7 @@ scipy
 scikit-image
 matplotlib
 tifffile
+psutil
 myst_parser
 sphinx==5.3.0
 sphinx_rtd_theme==1.1.1

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -139,19 +139,27 @@ vf = volume_fraction(img)
 vf = volume_fraction(img, phases={'pore':0, 'particle':1, 'binder':2})
 ```
 
-### Surface area
+### Specific surface area
 
-Surface area is calculated for each phase in a segmented image. The surface area returned is the fraction of interfacial faces with respect to the total number of faces n the image
+Per default, the specific surface area is calculated for each phase in a segmented image.
+Alternatively, the phases can be specified as phases={'phase1': 0, ...}.
+The method to compute surface area can be chosen as
+'face_counting', 'marching_cubes' or 'gradient'. A detailed comparison of these methods can be found in [Daubner _et al._](https://doi.org/10.1149/1945-7111/ad9a07).
+While face_counting is the fastest, the gradient method yields more accurate results for curved geometries.
 
 ```python
-from taufactor.metrics import surface_area
-# calculate the surface area of a single phase in an img
-sa = surface_area(img, phases=1)
+from taufactor.metrics import specific_surface_area
+# calculate the surface area of all phases in an image
+sa = specific_surface_area(img)
+
+# Surface area of a particular phase on anisotropic voxel grid (e.g. FIB-SEM data)
+sa = specific_surface_area(img, spacing=(1,1,3), phases={'pore': 0})
 
 # consider a three phase image with pore, particle and binder
 # where 0, 1, 2 correspond to pore, particle and binder respectively
-# calculate the surface area between pore and binder with periodic boundaries in y and z axes
-sa = surface_area(img, phases=[0,2], periodic=[0,1,1])
+# Use voxel face counting for fastest computation
+labels={'pore':0, 'particle':1, 'binder':2}
+sa = surface_area(img, phases=labels, method='face_counting')
 ```
 
 ### Triple phase boundary

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -16,3 +16,4 @@ tifffile==2023.2.3
 myst-parser==0.18.1
 scikit-image>=0.20.0
 scipy>=1.3
+psutil>=5.9.0

--- a/setup.py
+++ b/setup.py
@@ -17,6 +17,7 @@ requirements = [
     'tifffile>=2023.2.3',
     'scikit-image>=0.20.0',
     'scipy>=1.3'
+    'psutil>=5.9.0'
 ]
 
 setup_requirements = ['pytest-runner', ]

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ requirements = [
     'matplotlib>=3.4',
     'tifffile>=2023.2.3',
     'scikit-image>=0.20.0',
-    'scipy>=1.3'
+    'scipy>=1.3',
     'psutil>=5.9.0'
 ]
 

--- a/taufactor/taufactor.py
+++ b/taufactor/taufactor.py
@@ -1,6 +1,5 @@
 """Main module."""
 import numpy as np
-from IPython.display import clear_output
 from timeit import default_timer as timer
 import matplotlib.pyplot as plt
 import psutil
@@ -371,7 +370,7 @@ class PeriodicSolver(Solver):
             torch.cuda.reset_peak_memory_stats(device=self.device)
 
         start = timer()
-        while not self.converged and self.iter < iter_limit:
+        while not self.converged and self.iter <= iter_limit:
             out = torch.zeros_like(self.conc)
             for dim in range(1, 4):
                 for dr in [1, -1]:
@@ -615,7 +614,7 @@ class ElectrodeSolver():
         self.converged = False
         self.semiconverged = False
         self.old_fl = -1
-        self.iter = 0
+        self.iter = 1
 
         # Results
         self.tau_e = 0
@@ -787,7 +786,7 @@ class ElectrodeSolver():
         self.loss = []
         self.tau_es = []
 
-        while not self.converged and self.iter < iter_limit:
+        while not self.converged and self.iter <= iter_limit:
             out = self.sum_neighbours()
             out *= self.prefactor*self.crop(self.phase_map)
             out[self.prefactor == -1] = 0

--- a/tests/test_taufactor.py
+++ b/tests/test_taufactor.py
@@ -7,7 +7,7 @@ import torch as pt
 import numpy as np
 
 
-#  Testing the main solver
+###  Testing the main solver
 
 def test_solver_on_uniform_block():
     """Run solver on a block of ones."""
@@ -18,7 +18,6 @@ def test_solver_on_uniform_block():
     S.solve()
     assert np.around(S.tau, decimals=5) == 1.0
 
-
 def test_solver_on_uniform_rectangular_block_solver_dim():
     """Run solver on a block of ones."""
     l = 20
@@ -27,7 +26,6 @@ def test_solver_on_uniform_rectangular_block_solver_dim():
     S = tau.Solver(img, device=pt.device('cpu'))
     S.solve()
     assert np.around(S.tau, decimals=5) == 1.0
-
 
 def test_solver_on_uniform_rectangular_block_non_solver_dim():
     """Run solver on a block of ones."""
@@ -38,7 +36,6 @@ def test_solver_on_uniform_rectangular_block_non_solver_dim():
     S.solve()
     assert np.around(S.tau, decimals=5) == 1.0
 
-
 def test_solver_on_empty_block():
     """Run solver on a block of zeros."""
     l = 20
@@ -47,7 +44,6 @@ def test_solver_on_empty_block():
     S = tau.Solver(img, device=pt.device('cpu'))
     S.solve(verbose='per_iter', iter_limit=1000)
     assert S.tau == pt.inf
-
 
 def test_solver_on_strip_of_ones():
     """Run solver on a strip of ones, 1/4 volume of total"""
@@ -69,10 +65,7 @@ def test_solver_on_slanted_strip_of_ones():
         img[:, i, i:i+2, i:i+2] = 1
     S = tau.Solver(img, device=pt.device('cpu'))
     S.solve()
-    assert np.around(S.tau, decimals=5) == 4
-
-
-#  Testing the periodic solver
+    assert np.around(S.tau, decimals=5) == 7.49291
 
 def test_deadend():
     """Test deadend pore"""
@@ -84,6 +77,8 @@ def test_deadend():
     assert np.around(S.D_eff, decimals=5) == 0
     assert S.tau == np.inf
 
+
+###  Testing the periodic solver
 def test_periodic_solver_on_uniform_block():
     """Run periodic solver on a block of ones."""
     l = 20
@@ -93,7 +88,6 @@ def test_periodic_solver_on_uniform_block():
     S.solve()
     assert np.around(S.tau, decimals=5) == 1.0
 
-
 def test_periodic_solver_on_empty_block():
     """Run periodic solver on a block of zeros."""
     l = 20
@@ -102,7 +96,6 @@ def test_periodic_solver_on_empty_block():
     S = tau.PeriodicSolver(img, device=pt.device('cpu'))
     S.solve(verbose='per_iter', iter_limit=1000)
     assert S.tau == pt.inf
-
 
 def test_periodic_solver_on_strip_of_ones():
     """Run periodic solver on a strip of ones, 1/4 volume of total"""
@@ -115,8 +108,7 @@ def test_periodic_solver_on_strip_of_ones():
     assert np.around(S.tau, decimals=5) == 1
 
 
-#  Testing the multiphase solver
-
+###  Testing the multiphase solver
 def test_multiphase_and_solver_agree():
     """test mph and solver agree when Ds are the same"""
     x = 100
@@ -134,7 +126,6 @@ def test_multiphase_and_solver_agree():
 
     assert err < 0.02
 
-
 def test_mphsolver_on_empty_block():
     """Run mpsolver on a block of zeros."""
     l = 20
@@ -143,7 +134,6 @@ def test_mphsolver_on_empty_block():
     S.solve(iter_limit=1000)
     assert S.tau == pt.inf
 
-
 def test_mphsolver_on_ones_block():
     """Run mpsolver on a block of ones."""
     l = 20
@@ -151,7 +141,6 @@ def test_mphsolver_on_ones_block():
     S = tau.MultiPhaseSolver(img, device=pt.device('cpu'))
     S.solve(iter_limit=1000)
     assert np.around(S.tau, 4) == 1.0
-
 
 def test_mphsolver_on_halves():
     """Run mpsolver on a block of halves."""
@@ -163,7 +152,6 @@ def test_mphsolver_on_halves():
     print(S.D_eff, S.D_mean)
     assert np.around(S.tau, 4) == 1.0
 
-
 def test_mphsolver_on_strip_of_ones():
     """Run mpsolver on a strip of ones, 1/4 volume of total"""
     l = 20
@@ -173,7 +161,6 @@ def test_mphsolver_on_strip_of_ones():
     S = tau.MultiPhaseSolver(img, device=pt.device('cpu'))
     S.solve()
     assert np.around(S.tau, 4) == 1.0
-
 
 def test_mphsolver_on_strip_of_ones_and_twos():
     """Run solver on a strip of ones, 1/4 volume of total"""
@@ -186,7 +173,6 @@ def test_mphsolver_on_strip_of_ones_and_twos():
     S = tau.MultiPhaseSolver(img, cond, device=pt.device('cpu'))
     S.solve()
     assert np.around(S.tau, 4) == 1
-
 
 def test_mphsolver_on_strip_of_ones_and_twos_and_threes():
     """Run solver on a strip of ones, 1/4 volume of total"""
@@ -201,11 +187,9 @@ def test_mphsolver_on_strip_of_ones_and_twos_and_threes():
     assert np.around(S.tau, 4) == 1
 
 
-#  Testing the tau_e solver
-
+###  Testing the tau_e solver
 def test_taue_deadend():
     """Run solver on a deadend strip of ones"""
-
     l = 100
     img = np.zeros((l, l))
     img[:75, 45:55] = 1
@@ -217,7 +201,6 @@ def test_taue_deadend():
 
 def test_taue_throughpore():
     """Run taue solver on a strip of ones, 1/4 volume of total"""
-
     l = 100
     img = np.zeros((l, l))
     img[:, 45:55] = 1


### PR DESCRIPTION
When iter=0 and the convergence check is done for iter%100 == 0, the simulation immediatly stops which is not correct. This is fixed now and reveiled an error in the tests (also fixed with this commit.

Additionally, if verbose is not None, the solver writes out GPU/CPU stats to track the necessary RAM requirements.