### PR TITLE
perf: reduce memory usage

### DIFF
--- a/taufactor/benchmark.py
+++ b/taufactor/benchmark.py
@@ -110,7 +110,8 @@ def write_header_if_missing(outfile: str = DEFAULT_OUTFILE) -> None:
             f.write(
                 f"{'N':>4} {'struct':>10} {'solver':>16} {'dev':>4} {'conv':>6} "
                 f"{'Ttime(s)':>9} {'Wtime(s)':>9} {'iters':>6} {'tau':>8} "
-                f"{'VRAM(cur)':>10} {'VRAM(max)':>10} {'VRAM(res)':>10}\n"
+                f"{'VRAM_I_max':>10} {'VRAM_I_cur':>10} "
+                f"{'VRAM_S_max':>10} {'VRAM_S_cur':>10}\n"
             )
             f.write("=" * 120 + "\n")
 
@@ -120,7 +121,8 @@ def append_row_to_file(row: dict, outfile: str = DEFAULT_OUTFILE) -> None:
     line = (
         f"{row['N']:4d} {row['structure'][:10]:>10} {row['solver'][:16]:>16} {row['device'][:4]:>4} {row['conv_crit']:.4f} "
         f"{row['total_time']:9.3f} {row['solve_time']:9.3f} {row['iterations']:6d} {row['taufactor']:8.3f} "
-        f"{row['torch_cur']:10.2f} {row['torch_max']:10.2f} {row['torch_res']:10.2f}\n"
+        f"{row['torch_init_max']:10.2f} {row['torch_init_cur']:10.2f} "
+        f"{row['torch_solve_max']:10.2f} {row['torch_solve_cur']:10.2f}\n"
     )
     with open(outfile, "a", encoding="utf-8") as f:
         f.write(line)
@@ -156,33 +158,32 @@ def run_benchmark_case(
 
     if device == "cuda":
         torch.cuda.synchronize()
+        torch.cuda.reset_peak_memory_stats()
     start_time = time.perf_counter()
 
-    buf = io.StringIO()
-    with redirect_stdout(buf):
+    with redirect_stdout(io.StringIO()):
         solver = solver_cls(cube, device=device, **solver_kwargs)
+        if device == "cuda":
+            torch.cuda.synchronize()
+            torch_init_max = torch.cuda.max_memory_allocated() / 1e6
+            torch_init_cur = torch.cuda.memory_allocated() / 1e6
+            torch.cuda.reset_peak_memory_stats()
         solver.solve(iter_limit=iter_limit, conv_crit=conv_crit, **solve_kwargs)
 
         if device == "cuda":
             torch.cuda.synchronize()
         end_time = time.perf_counter()
 
-    out = buf.getvalue().splitlines()
-
     iterations = int(solver.iter)
     wall_time = float(solver.walltime)
     taufactor = float(solver.tau[0])
 
-    torch_line = next((line for line in out if "GPU-RAM" in line), "")
-    if torch_line:
-        parts = torch_line.replace("(", "").replace(")", "").replace(",", "").split()
-        torch_cur = float(parts[2])
-        torch_max = float(parts[6])
-        torch_res = float(parts[8])
+    if device == "cuda":
+        torch_solve_max = torch.cuda.max_memory_allocated() / 1e6
+        torch_solve_cur = torch.cuda.memory_allocated() / 1e6
     else:
-        torch_cur = 0.0
-        torch_max = 0.0
-        torch_res = 0.0
+        torch_init_max = torch_init_cur = 0.0
+        torch_solve_max = torch_solve_cur = 0.0
 
     return {
         "N": N,
@@ -194,9 +195,10 @@ def run_benchmark_case(
         "solve_time": wall_time,
         "iterations": iterations,
         "taufactor": taufactor,
-        "torch_cur": torch_cur,
-        "torch_max": torch_max,
-        "torch_res": torch_res,
+        "torch_init_max": torch_init_max,
+        "torch_init_cur": torch_init_cur,
+        "torch_solve_max": torch_solve_max,
+        "torch_solve_cur": torch_solve_cur,
     }
 
 

--- a/taufactor/electrode.py
+++ b/taufactor/electrode.py
@@ -49,7 +49,6 @@ class ElectrodeSolver(SORSolver):
         for i in range(2):
             vec = torch.unsqueeze(vec, -1)
         vec = torch.unsqueeze(vec, 0)
-        vec = vec.repeat(self.batch_size, 1, self.Ny, self.Nz, )
         return self._pad(mask * vec, [self.left_bc * 2, 0])
 
     def init_conductive_neighbours(self, img, mask):
@@ -142,21 +141,24 @@ class PeriodicElectrodeSolver(ElectrodeSolver):
     Solver with periodic boundary conditions in y and z direction.
     """
     def init_conductive_neighbours(self, img, mask):
-        # Periodic Y/Z: pad then strip Y/Z ghosts before neighbour sum via rolling
-        img2 = self._pad(mask, [2, 0])[:, :, 1:-1, 1:-1]
-        cond_nn = self._sum_by_rolling(img2)
-        del img2
-        cond_nn = cond_nn[:, 1:-1]
+        padded = self._pad(mask, [2, 0])[:, :, 1:-1, 1:-1]
+        cond_nn = torch.empty_like(mask)
+        self._periodic_yz_neighbour_sum_from_padded(padded, cond_nn)
+        del padded
         cond_nn.masked_fill_(mask == 0, torch.inf)
         return cond_nn
 
     def init_reactive_neighbours(self, img):
         reac = (img == self.reac_label).to(dtype=self.precision)
-        img2 = self._pad(reac)[:, :, 1:-1, 1:-1]
+        padded = self._pad(reac)[:, :, 1:-1, 1:-1]
         del reac
-        reac_nn = self._sum_by_rolling(img2)
-        del img2
-        reac_nn = reac_nn[:, 1:-1]
+        reac_nn = torch.empty(
+            (self.batch_size, self.Nx, self.Ny, self.Nz),
+            dtype=self.precision,
+            device=self.device,
+        )
+        self._periodic_yz_neighbour_sum_from_padded(padded, reac_nn)
+        del padded
         reac_nn.masked_fill_(img != self.cond_label, 0)
         return reac_nn
 
@@ -241,7 +243,6 @@ class ImpedanceSolver(SORSolver):
         for i in range(2):
             vec = torch.unsqueeze(vec, -1)
         vec = torch.unsqueeze(vec, 0)
-        vec = vec.repeat(self.batch_size, 1, self.Ny, self.Nz, )
         mask_f = mask.to(vec.dtype) if mask.dtype == torch.bool else mask
         return self._pad(mask_f * vec, [2 * self.left_bc, 0]).to(self.device)
 
@@ -258,16 +259,18 @@ class ImpedanceSolver(SORSolver):
         :rtype: cp.array
         """      
         # Conducting nearest neighbours
-        img2 = self._pad(mask, [2, 0])
-        cond_nn = self._sum_by_rolling(img2)
-        cond_nn = self._crop(cond_nn, 1)
+        padded = self._pad(mask, [2, 0])
+        cond_nn = torch.empty_like(mask)
+        self._neighbour_sum_from_padded(padded, cond_nn)
+        del padded
 
         # Capacitive nearest neighbours
-        img2 = torch.zeros_like(img)
-        img2[img==self.reac_label] = 1
-        img2 = self._pad(img2)
-        reac_nn = self._sum_by_rolling(img2)
-        reac_nn = self._crop(reac_nn, 1)
+        reac = (img == self.reac_label).to(dtype=self.precision)
+        padded = self._pad(reac)
+        del reac
+        reac_nn = torch.empty_like(mask)
+        self._neighbour_sum_from_padded(padded, reac_nn)
+        del padded
 
         # Masking conducting voxels
         cond_nn[mask == 0] = 0.0

--- a/taufactor/electrode.py
+++ b/taufactor/electrode.py
@@ -36,11 +36,11 @@ class ElectrodeSolver(SORSolver):
         self.dx = spacing or 1
         super().__init__(img, omega=omega, device=device)
         self.c_x = 0
+        # ElectrodeSolver never reads cpu_img after init (unlike through-transport)
+        self.cpu_img = None
 
     def return_mask(self, img):
-        mask = torch.zeros_like(img)
-        mask[img==self.cond_label] = 1
-        return mask
+        return (img == self.cond_label).to(dtype=self.precision)
 
     def init_field(self, mask):
         x = np.arange(self.Nx)+0.5
@@ -52,21 +52,26 @@ class ElectrodeSolver(SORSolver):
         vec = vec.repeat(self.batch_size, 1, self.Ny, self.Nz, )
         return self._pad(mask * vec, [self.left_bc * 2, 0])
 
-    def init_conductive_neighbours(self, img):
-        mask = self.return_mask(img)
-        img2 = self._pad(mask, [2, 0])
-        cond_nn = self._sum_by_rolling(img2)
-        cond_nn = self._crop(cond_nn, 1)
-        cond_nn[mask == 0] = torch.inf
+    def init_conductive_neighbours(self, img, mask):
+        padded = self._pad(mask, [2, 0])
+        cond_nn = torch.empty_like(mask)
+        self._neighbour_sum_from_padded(padded, cond_nn)
+        del padded
+        cond_nn.masked_fill_(mask == 0, torch.inf)
         return cond_nn
 
     def init_reactive_neighbours(self, img):
-        img2 = torch.zeros_like(img)
-        img2[img==self.reac_label] = 1
-        img2 = self._pad(img2)
-        reac_nn = self._sum_by_rolling(img2)
-        reac_nn = self._crop(reac_nn, 1)
-        reac_nn[img != self.cond_label] = 0.0
+        reac = (img == self.reac_label).to(dtype=self.precision)
+        padded = self._pad(reac)
+        del reac
+        reac_nn = torch.empty(
+            (self.batch_size, self.Nx, self.Ny, self.Nz),
+            dtype=self.precision,
+            device=self.device,
+        )
+        self._neighbour_sum_from_padded(padded, reac_nn)
+        del padded
+        reac_nn.masked_fill_(img != self.cond_label, 0)
         return reac_nn
 
     def compute_metrics(self):
@@ -136,21 +141,23 @@ class PeriodicElectrodeSolver(ElectrodeSolver):
     """
     Solver with periodic boundary conditions in y and z direction.
     """
-    def init_conductive_neighbours(self, img):
-        mask = self.return_mask(img)
+    def init_conductive_neighbours(self, img, mask):
+        # Periodic Y/Z: pad then strip Y/Z ghosts before neighbour sum via rolling
         img2 = self._pad(mask, [2, 0])[:, :, 1:-1, 1:-1]
         cond_nn = self._sum_by_rolling(img2)
+        del img2
         cond_nn = cond_nn[:, 1:-1]
-        cond_nn[mask == 0] = torch.inf
+        cond_nn.masked_fill_(mask == 0, torch.inf)
         return cond_nn
 
     def init_reactive_neighbours(self, img):
-        img2 = torch.zeros_like(img)
-        img2[img==self.reac_label] = 1
-        img2 = self._pad(img2)[:, :, 1:-1, 1:-1]
+        reac = (img == self.reac_label).to(dtype=self.precision)
+        img2 = self._pad(reac)[:, :, 1:-1, 1:-1]
+        del reac
         reac_nn = self._sum_by_rolling(img2)
+        del img2
         reac_nn = reac_nn[:, 1:-1]
-        reac_nn[img != self.cond_label] = 0.0
+        reac_nn.masked_fill_(img != self.cond_label, 0)
         return reac_nn
 
     def apply_boundary_conditions(self):
@@ -181,12 +188,13 @@ class ImpedanceSolver(SORSolver):
             )
         
         torch_img = torch.tensor(self.cpu_img, dtype=self.precision, device=self.device)
-        self.mask = torch.zeros_like(torch_img)
-        self.mask[torch_img==self.cond_label] = 1
-        self.cond_nn, self.reac_nn = self.count_neighbours(torch_img, self.mask)
+        self.mask = torch_img == self.cond_label  # bool — 8x smaller than float32
+        mask_f = self.mask.to(self.precision)
+        self.cond_nn, self.reac_nn = self.count_neighbours(torch_img, mask_f)
+        del torch_img, mask_f
 
         # Volume fraction (slice-wise)
-        self.vol_x = torch.mean(self.mask, (0, 2, 3)).cpu().numpy()
+        self.vol_x = torch.mean(self.mask.to(self.precision), (0, 2, 3)).cpu().numpy()
         self.a_x = (torch.sum(self.reac_nn, (0, 2, 3)) / (self.Ny*self.Nz*self.dx)).cpu().numpy()
 
         # Define frequency, resistance and capacitance
@@ -207,14 +215,12 @@ class ImpedanceSolver(SORSolver):
         self.c_x = 0
 
     def return_mask(self, img):
-        mask = torch.zeros_like(img)
-        mask[img==self.cond_label] = 1
-        return mask
+        return (img == self.cond_label).to(dtype=self.precision)
 
     def init_field(self, img):
         return None
     
-    def init_conductive_neighbours(self, img):
+    def init_conductive_neighbours(self, img, mask):
         return None
 
     def init_field_internal(self, mask):
@@ -236,7 +242,8 @@ class ImpedanceSolver(SORSolver):
             vec = torch.unsqueeze(vec, -1)
         vec = torch.unsqueeze(vec, 0)
         vec = vec.repeat(self.batch_size, 1, self.Ny, self.Nz, )
-        return self._pad(mask * vec, [2 * self.left_bc, 0]).to(self.device)
+        mask_f = mask.to(vec.dtype) if mask.dtype == torch.bool else mask
+        return self._pad(mask_f * vec, [2 * self.left_bc, 0]).to(self.device)
 
     def count_neighbours(self, img, mask):
         """
@@ -291,6 +298,12 @@ class ImpedanceSolver(SORSolver):
         # init field
         self.frc = self.frequency[0]*self.resistance*self.capacitance
         self.field = self.init_field_internal(self.mask)
+        if self.work is None or self.work.dtype != self.field.dtype:
+            self.work = torch.empty(
+                (self.batch_size, self.Nx, self.Ny, self.Nz),
+                dtype=self.field.dtype,
+                device=self.device,
+            )
 
         with torch.no_grad():
             start = timer()
@@ -303,7 +316,7 @@ class ImpedanceSolver(SORSolver):
                 # factor = (self.cond_nn + 2*self.reac_nn * 1j*self.frc/(2+1j*self.frc))**-1
                 # Variant 2: (N_i + S_i * j*r*frequency*c)**-1
                 factor = (self.cond_nn + self.reac_nn * 1j*self.frc)**-1
-                factor[self.mask == 0] = 0
+                factor.masked_fill_(~self.mask, 0)
                 factor[(self.cond_nn+self.reac_nn) == 0] = 0
 
                 self.impedance.append(0)
@@ -312,11 +325,11 @@ class ImpedanceSolver(SORSolver):
                 self.iter = 0
                 while not self.converged and self.iter < iter_limit:
                     self.apply_boundary_conditions()
-                    increment = self.sum_weighted_neighbours()
-                    increment *= factor
-                    increment -= self.field[:, 1:-1, 1:-1, 1:-1]
-                    increment *= self.cb[self.iter % 2]
-                    self.field[:, 1:-1, 1:-1, 1:-1] += increment
+                    self.sum_weighted_neighbours(self.work)
+                    self.work.mul_(factor)
+                    self.work.sub_(self.field[:, 1:-1, 1:-1, 1:-1])
+                    self._apply_chequerboard(self.work)
+                    self.field[:, 1:-1, 1:-1, 1:-1].add_(self.work)
                     self.iter += 1
 
                     if self.iter % 100 == 0:

--- a/taufactor/electrode.py
+++ b/taufactor/electrode.py
@@ -298,14 +298,13 @@ class ImpedanceSolver(SORSolver):
         # init field
         self.frc = self.frequency[0]*self.resistance*self.capacitance
         self.field = self.init_field_internal(self.mask)
-        if self.work is None or self.work.dtype != self.field.dtype:
-            self.work = torch.empty(
+
+        with torch.no_grad():
+            increment = torch.empty(
                 (self.batch_size, self.Nx, self.Ny, self.Nz),
                 dtype=self.field.dtype,
                 device=self.device,
             )
-
-        with torch.no_grad():
             start = timer()
             for f in self.frequency:
                 self.frc = f*self.resistance*self.capacitance
@@ -325,11 +324,11 @@ class ImpedanceSolver(SORSolver):
                 self.iter = 0
                 while not self.converged and self.iter < iter_limit:
                     self.apply_boundary_conditions()
-                    self.sum_weighted_neighbours(self.work)
-                    self.work.mul_(factor)
-                    self.work.sub_(self.field[:, 1:-1, 1:-1, 1:-1])
-                    self._apply_chequerboard(self.work)
-                    self.field[:, 1:-1, 1:-1, 1:-1].add_(self.work)
+                    self.sum_weighted_neighbours(increment)
+                    increment *= factor
+                    increment -= self.field[:, 1:-1, 1:-1, 1:-1]
+                    self._apply_chequerboard(increment)
+                    self.field[:, 1:-1, 1:-1, 1:-1] += increment
                     self.iter += 1
 
                     if self.iter % 100 == 0:

--- a/taufactor/taufactor.py
+++ b/taufactor/taufactor.py
@@ -40,28 +40,49 @@ class SORSolver(ABC):
         # Overrelaxation factor for SOR
         if omega is None:
             omega = 2 - torch.pi / (1.5 * self.Nx)
+        self.omega = float(omega)
 
-        # Initialise pytorch tensors
-        torch_img = torch.tensor(self.cpu_img, dtype=self.precision, device=self.device)
+        # Labels as uint8 on device (4x smaller than float32) to cut init peak VRAM
+        torch_img = torch.as_tensor(self.cpu_img, device=self.device)
+        if torch_img.dtype != torch.uint8:
+            torch_img = torch_img.to(torch.uint8)
         mask = self.return_mask(torch_img)
-        vol_x = torch.mean(mask, (2, 3)) # volume fraction
-        self.field = self.init_field(mask)
-        self.factor = self.init_conductive_neighbours(torch_img)
+        if mask.dtype not in (torch.float16, torch.float32, torch.float64):
+            mask = mask.to(dtype=self.precision)
+        vol_x = torch.mean(mask, (2, 3))  # volume fraction
 
-        # Optional for electrode simulations
+        # Reactive neighbours before field so we can free torch_img early
         reac_nn = self.init_reactive_neighbours(torch_img)
+        self.factor = self.init_conductive_neighbours(torch_img, mask)
+        del torch_img
         if reac_nn is not None:
-            a_x = (torch.sum(reac_nn, (2, 3)) / (self.Ny*self.Nz*self.dx)) # surface area
-            # Pre-compute reaction prefactor
-            k_0 = torch.mean(vol_x, 1) / torch.mean(a_x*self.dx, 1) / self.Nx**2
-            reac_nn = reac_nn * k_0[:, None, None, None]
-            self.factor += reac_nn
-            self.factor[self.factor == 0] = torch.inf
+            a_x = (torch.sum(reac_nn, (2, 3)) / (self.Ny * self.Nz * self.dx))
+            k_0 = torch.mean(vol_x, 1) / torch.mean(a_x * self.dx, 1) / self.Nx**2
+            reac_nn.mul_(k_0[:, None, None, None])
+            self.factor.add_(reac_nn)
+            del reac_nn
+            self.factor.masked_fill_(self.factor == 0, torch.inf)
             self.a_x = a_x.cpu().numpy()
             self.k_0 = k_0.cpu().numpy()
+            if self.device.type == 'cuda':
+                torch.cuda.empty_cache()
 
+        self.field = self.init_field(mask)
         self.vol_x = vol_x.cpu().numpy()
-        self.cb = self._init_chequerboard(omega)
+        del mask, vol_x
+        if self.device.type == 'cuda':
+            torch.cuda.empty_cache()
+
+        self.cb, self._cb_inv = self._init_chequerboard()
+        # Preallocate hot-loop buffer (ImpedanceSolver sets field later)
+        if self.field is not None:
+            self.work = torch.empty(
+                (self.batch_size, self.Nx, self.Ny, self.Nz),
+                dtype=self.field.dtype,
+                device=self.device,
+            )
+        else:
+            self.work = None
 
         # Init params
         self.converged = False
@@ -81,7 +102,7 @@ class SORSolver(ABC):
         """Return initial padded field [bs,Nx+2,Ny+2,Nz+2]."""
 
     @abstractmethod 
-    def init_conductive_neighbours(self, img: torch.Tensor) -> torch.Tensor:
+    def init_conductive_neighbours(self, img: torch.Tensor, mask: torch.Tensor) -> torch.Tensor:
         """N_i: amount of conductive neighbours (cond_nn)"""
 
     @abstractmethod 
@@ -96,15 +117,19 @@ class SORSolver(ABC):
     def apply_boundary_conditions(self):
         """Default: Dirichlet in x and no-flux in y and z direction."""
 
-    def sum_weighted_neighbours(self) -> torch.Tensor:
-        """Default: isotropic 6-neighbor SOR increment on interior."""
-        sum = self.field[:, 2:, 1:-1, 1:-1] + \
-              self.field[:, :-2, 1:-1, 1:-1] + \
-              self.field[:, 1:-1, 2:, 1:-1] + \
-              self.field[:, 1:-1, :-2, 1:-1] + \
-              self.field[:, 1:-1, 1:-1, 2:] + \
-              self.field[:, 1:-1, 1:-1, :-2]
-        return sum
+    def sum_weighted_neighbours(self, out: "torch.Tensor") -> None:
+        """Isotropic 6-neighbor sum into a preallocated interior buffer."""
+        torch.add(self.field[:, 2:, 1:-1, 1:-1], self.field[:, :-2, 1:-1, 1:-1], out=out)
+        out.add_(self.field[:, 1:-1, 2:, 1:-1])
+        out.add_(self.field[:, 1:-1, :-2, 1:-1])
+        out.add_(self.field[:, 1:-1, 1:-1, 2:])
+        out.add_(self.field[:, 1:-1, 1:-1, :-2])
+
+    def _apply_chequerboard(self, work: "torch.Tensor") -> None:
+        """Zero the inactive colour and scale by omega, in-place."""
+        work.mul_(self.omega)
+        mask_zero = self._cb_inv if (self.iter % 2 == 0) else self.cb
+        work.masked_fill_(mask_zero, 0)
     
     def plot_stats(self, relative_error):
         """Default: No plotting output."""
@@ -176,12 +201,11 @@ class SORSolver(ABC):
             start = timer()
             while not self.converged and self.iter < iter_limit:
                 self.apply_boundary_conditions()
-                increment = self.sum_weighted_neighbours()
-                increment /= self.factor
-                increment -= self.field[:, 1:-1, 1:-1, 1:-1]
-                # Multiply with checkerboard and over-relaxation factor
-                increment *= self.cb[self.iter % 2]
-                self.field[:, 1:-1, 1:-1, 1:-1] += increment
+                self.sum_weighted_neighbours(self.work)
+                self.work.div_(self.factor)
+                self.work.sub_(self.field[:, 1:-1, 1:-1, 1:-1])
+                self._apply_chequerboard(self.work)
+                self.field[:, 1:-1, 1:-1, 1:-1].add_(self.work)
                 self.iter += 1
 
                 if self.iter % 100 == 0:
@@ -218,14 +242,24 @@ class SORSolver(ABC):
             device = torch.device(device)
         return device
 
-    def _init_chequerboard(self, omega: float):
-        """Creates a chequerboard to ensure neighbouring pixels dont update,
-        which can cause instability"""
-        cb = np.zeros([self.Nx, self.Ny, self.Nz])
-        a, b, c = np.meshgrid(range(self.Nx), range(self.Ny), range(self.Nz), indexing='ij')
-        cb[(a + b + c) % 2 == 0] = 1
-        return [torch.tensor(omega*cb, dtype=self.precision, device=self.device),
-                torch.tensor(omega*(1-cb), dtype=self.precision, device=self.device)]
+    def _init_chequerboard(self):
+        """Bool chequerboard on device (True = even i+j+k), plus precomputed inverse.
+
+        Built in z-chunks to avoid host meshgrid / large int64 temporaries.
+        """
+        cb = torch.empty((self.Nx, self.Ny, self.Nz), dtype=torch.bool, device=self.device)
+        xy = (
+            torch.arange(self.Nx, device=self.device)[:, None]
+            + torch.arange(self.Ny, device=self.device)[None, :]
+        ) & 1
+        chunk = 64
+        for z0 in range(0, self.Nz, chunk):
+            z1 = min(self.Nz, z0 + chunk)
+            z = torch.arange(z0, z1, device=self.device)
+            cb[:, :, z0:z1] = ((xy.unsqueeze(-1) + z) & 1) == 0
+        cb_inv = torch.empty_like(cb)
+        torch.logical_not(cb, out=cb_inv)
+        return cb, cb_inv
 
     @staticmethod
     def _pad(img: torch.Tensor, vals=(0,0,0,0,0,0)) -> torch.Tensor:
@@ -254,6 +288,15 @@ class SORSolver(ABC):
             for dr in [1, -1]:
                 sum += torch.roll(tensor, dr, dim)
         return sum
+
+    @staticmethod
+    def _neighbour_sum_from_padded(padded: "torch.Tensor", out: "torch.Tensor") -> None:
+        """6-neighbour sum from a +1-padded volume into an interior-sized buffer."""
+        torch.add(padded[:, 2:, 1:-1, 1:-1], padded[:, :-2, 1:-1, 1:-1], out=out)
+        out.add_(padded[:, 1:-1, 2:, 1:-1])
+        out.add_(padded[:, 1:-1, :-2, 1:-1])
+        out.add_(padded[:, 1:-1, 1:-1, 2:])
+        out.add_(padded[:, 1:-1, 1:-1, :-2])
 
     def _end_simulation(self, iterations: int, verbose: bool):
         if self.converged:
@@ -400,16 +443,17 @@ class Solver(ThroughTransportSolver):
                 "If you have more than one conductive phase, use the multi-phase solver.")
 
     def return_mask(self, img):
-        return img
+        return img.to(dtype=self.precision)
 
-    def init_conductive_neighbours(self, mask):
+    def init_conductive_neighbours(self, img, mask):
         """Saves the number of conductive neighbours for flux calculation"""
         img2 = self._pad(mask, [2, 2])
-        nn = self._sum_by_rolling(img2)
-        nn = self._crop(nn, 1)
+        nn = torch.empty_like(mask)
+        self._neighbour_sum_from_padded(img2, nn)
+        del img2
         # avoid div 0 errors
-        nn[mask == 0] = torch.inf
-        nn[nn == 0] = torch.inf
+        nn.masked_fill_(mask == 0, torch.inf)
+        nn.masked_fill_(nn == 0, torch.inf)
         return nn
 
     def vertical_flux(self) -> torch.Tensor:
@@ -459,9 +503,9 @@ class AnisotropicSolver(Solver):
         self.Kz = (dx/dz)**2
         super().__init__(img, omega=omega, D_0=D_0, device=device)
 
-    def init_conductive_neighbours(self, img):
+    def init_conductive_neighbours(self, img, mask):
         """Saves the number of conductive neighbours for flux calculation"""
-        img2 = self._pad(img, [2, 2])
+        img2 = self._pad(mask, [2, 2])
         nn = torch.zeros_like(img2, dtype=self.precision)
         # iterate through shifts in the spatial dimensions
         factor = [1.0, self.Ky, self.Kz]
@@ -469,16 +513,17 @@ class AnisotropicSolver(Solver):
             for dr in [1, -1]:
                 nn += torch.roll(img2, dr, dim)*factor[dim-1]
         nn = self._crop(nn, 1)
-        nn[img == 0] = torch.inf
+        nn[mask == 0] = torch.inf
         nn[nn == 0] = torch.inf
         return nn
     
-    def sum_weighted_neighbours(self):
-        """Default: isotropic 6-neighbor SOR increment on interior."""
-        sum = self.field[:, 2:, 1:-1, 1:-1] + self.field[:, :-2, 1:-1, 1:-1] + \
-              self.Ky*(self.field[:, 1:-1, 2:, 1:-1] + self.field[:, 1:-1, :-2, 1:-1]) + \
-              self.Kz*(self.field[:, 1:-1, 1:-1, 2:] + self.field[:, 1:-1, 1:-1, :-2])
-        return sum
+    def sum_weighted_neighbours(self, out):
+        """Anisotropic 6-neighbor sum into a preallocated interior buffer."""
+        torch.add(self.field[:, 2:, 1:-1, 1:-1], self.field[:, :-2, 1:-1, 1:-1], out=out)
+        out.add_(self.field[:, 1:-1, 2:, 1:-1], alpha=self.Ky)
+        out.add_(self.field[:, 1:-1, :-2, 1:-1], alpha=self.Ky)
+        out.add_(self.field[:, 1:-1, 1:-1, 2:], alpha=self.Kz)
+        out.add_(self.field[:, 1:-1, 1:-1, :-2], alpha=self.Kz)
 
 
 class PeriodicSolver(Solver):
@@ -493,11 +538,11 @@ class PeriodicSolver(Solver):
         :class:`Solver`.
     """
 
-    def init_conductive_neighbours(self, img):
-        img2 = self._pad(img, [2, 2])[:, :, 1:-1, 1:-1]
+    def init_conductive_neighbours(self, img, mask):
+        img2 = self._pad(mask, [2, 2])[:, :, 1:-1, 1:-1]
         nn = self._sum_by_rolling(img2)
         nn = nn[:, 1:-1]
-        nn[img == 0] = torch.inf
+        nn[mask == 0] = torch.inf
         nn[nn == 0] = torch.inf
         return nn
 
@@ -585,8 +630,8 @@ class MultiPhaseSolver(ThroughTransportSolver):
         hm[valid] = 2 * a[valid] * b[valid] / denom[valid]
         return hm
 
-    def init_conductive_neighbours(self, img):
-        diff_map = torch.zeros_like(img)
+    def init_conductive_neighbours(self, img, mask):
+        diff_map = torch.zeros(img.shape, dtype=self.precision, device=img.device)
         for phase, D_p in self.Ds.items():
             diff_map[img == phase] = D_p
 
@@ -606,14 +651,13 @@ class MultiPhaseSolver(ThroughTransportSolver):
         factor[factor == 0] = torch.inf
         return factor
     
-    def sum_weighted_neighbours(self) -> torch.Tensor:
-        sum = self.field[:, 2:,  1:-1, 1:-1] * self.D_x[:, 1: , :, :] + \
-              self.field[:, :-2, 1:-1, 1:-1] * self.D_x[:, :-1, :, :] + \
-              self.field[:, 1:-1, 2:,  1:-1] * self.D_y[:, :, 1: , :] + \
-              self.field[:, 1:-1, :-2, 1:-1] * self.D_y[:, :, :-1, :] + \
-              self.field[:, 1:-1, 1:-1, 2: ] * self.D_z[:, :, :, 1: ] + \
-              self.field[:, 1:-1, 1:-1, :-2] * self.D_z[:, :, :, :-1]
-        return sum
+    def sum_weighted_neighbours(self, out) -> None:
+        torch.mul(self.field[:, 2:, 1:-1, 1:-1], self.D_x[:, 1:, :, :], out=out)
+        out.addcmul_(self.field[:, :-2, 1:-1, 1:-1], self.D_x[:, :-1, :, :])
+        out.addcmul_(self.field[:, 1:-1, 2:, 1:-1], self.D_y[:, :, 1:, :])
+        out.addcmul_(self.field[:, 1:-1, :-2, 1:-1], self.D_y[:, :, :-1, :])
+        out.addcmul_(self.field[:, 1:-1, 1:-1, 2:], self.D_z[:, :, :, 1:])
+        out.addcmul_(self.field[:, 1:-1, 1:-1, :-2], self.D_z[:, :, :, :-1])
 
     def vertical_flux(self):
         '''Calculates the vertical flux through the volume'''
@@ -626,8 +670,8 @@ class MultiPhaseSolver(ThroughTransportSolver):
 class PeriodicMultiPhaseSolver(MultiPhaseSolver):
     """Multi-phase solver with periodic boundary conditions in y and z."""
 
-    def init_conductive_neighbours(self, img):
-        diff_map = torch.zeros_like(img)
+    def init_conductive_neighbours(self, img, mask):
+        diff_map = torch.zeros(img.shape, dtype=self.precision, device=img.device)
         for phase, D_p in self.Ds.items():
             diff_map[img == phase] = D_p
 

--- a/taufactor/taufactor.py
+++ b/taufactor/taufactor.py
@@ -272,16 +272,6 @@ class SORSolver(ABC):
         return img[:, c:-c, c:-c, c:-c]
     
     @staticmethod
-    def _sum_by_rolling(tensor: torch.Tensor):
-        """Sum up active neighbours and return new tensor"""
-        sum = torch.zeros_like(tensor)
-        # iterate through shifts in the spatial dimensions
-        for dim in range(1, 4):
-            for dr in [1, -1]:
-                sum += torch.roll(tensor, dr, dim)
-        return sum
-
-    @staticmethod
     def _neighbour_sum_from_padded(padded: torch.Tensor, out: torch.Tensor) -> None:
         """6-neighbour sum from a +1-padded volume into an interior-sized buffer."""
         torch.add(padded[:, 2:, 1:-1, 1:-1], padded[:, :-2, 1:-1, 1:-1], out=out)
@@ -289,6 +279,22 @@ class SORSolver(ABC):
         out.add_(padded[:, 1:-1, :-2, 1:-1])
         out.add_(padded[:, 1:-1, 1:-1, 2:])
         out.add_(padded[:, 1:-1, 1:-1, :-2])
+
+    @staticmethod
+    def _periodic_yz_neighbour_sum_from_padded(
+        padded: torch.Tensor, out: torch.Tensor
+    ) -> None:
+        """6-neighbour sum with X ghosts and periodic Y/Z boundaries."""
+        center = padded[:, 1:-1]
+        torch.add(padded[:, :-2], padded[:, 2:], out=out)
+        out[:, :, 1:].add_(center[:, :, :-1])
+        out[:, :, :-1].add_(center[:, :, 1:])
+        out[:, :, 0].add_(center[:, :, -1])
+        out[:, :, -1].add_(center[:, :, 0])
+        out[:, :, :, 1:].add_(center[:, :, :, :-1])
+        out[:, :, :, :-1].add_(center[:, :, :, 1:])
+        out[:, :, :, 0].add_(center[:, :, :, -1])
+        out[:, :, :, -1].add_(center[:, :, :, 0])
 
     def _end_simulation(self, iterations: int, verbose: bool):
         if self.converged:
@@ -325,7 +331,6 @@ class ThroughTransportSolver(SORSolver):
         for i in range(2):
             vec = torch.unsqueeze(vec, -1)
         vec = torch.unsqueeze(vec, 0)
-        vec = vec.repeat(self.batch_size, 1, self.Ny, self.Nz, )
         return self._pad(mask * vec, [2*self.top_bc, 2*self.bot_bc])
 
     def compute_metrics(self):
@@ -531,9 +536,10 @@ class PeriodicSolver(Solver):
     """
 
     def init_conductive_neighbours(self, img, mask):
-        img2 = self._pad(mask, [2, 2])[:, :, 1:-1, 1:-1]
-        nn = self._sum_by_rolling(img2)
-        nn = nn[:, 1:-1]
+        padded = self._pad(mask, [2, 2])[:, :, 1:-1, 1:-1]
+        nn = torch.empty_like(mask)
+        self._periodic_yz_neighbour_sum_from_padded(padded, nn)
+        del padded
         nn[mask == 0] = torch.inf
         nn[nn == 0] = torch.inf
         return nn

--- a/taufactor/taufactor.py
+++ b/taufactor/taufactor.py
@@ -117,7 +117,7 @@ class SORSolver(ABC):
     def apply_boundary_conditions(self):
         """Default: Dirichlet in x and no-flux in y and z direction."""
 
-    def sum_weighted_neighbours(self, out: "torch.Tensor") -> None:
+    def sum_weighted_neighbours(self, out: torch.Tensor) -> None:
         """Isotropic 6-neighbor sum into a preallocated interior buffer."""
         torch.add(self.field[:, 2:, 1:-1, 1:-1], self.field[:, :-2, 1:-1, 1:-1], out=out)
         out.add_(self.field[:, 1:-1, 2:, 1:-1])
@@ -125,7 +125,7 @@ class SORSolver(ABC):
         out.add_(self.field[:, 1:-1, 1:-1, 2:])
         out.add_(self.field[:, 1:-1, 1:-1, :-2])
 
-    def _apply_chequerboard(self, work: "torch.Tensor") -> None:
+    def _apply_chequerboard(self, work: torch.Tensor) -> None:
         """Zero the inactive colour and scale by omega, in-place."""
         work.mul_(self.omega)
         mask_zero = self._cb_inv if (self.iter % 2 == 0) else self.cb
@@ -290,7 +290,7 @@ class SORSolver(ABC):
         return sum
 
     @staticmethod
-    def _neighbour_sum_from_padded(padded: "torch.Tensor", out: "torch.Tensor") -> None:
+    def _neighbour_sum_from_padded(padded: torch.Tensor, out: torch.Tensor) -> None:
         """6-neighbour sum from a +1-padded volume into an interior-sized buffer."""
         torch.add(padded[:, 2:, 1:-1, 1:-1], padded[:, :-2, 1:-1, 1:-1], out=out)
         out.add_(padded[:, 1:-1, 2:, 1:-1])

--- a/taufactor/taufactor.py
+++ b/taufactor/taufactor.py
@@ -64,25 +64,12 @@ class SORSolver(ABC):
             self.factor.masked_fill_(self.factor == 0, torch.inf)
             self.a_x = a_x.cpu().numpy()
             self.k_0 = k_0.cpu().numpy()
-            if self.device.type == 'cuda':
-                torch.cuda.empty_cache()
 
         self.field = self.init_field(mask)
         self.vol_x = vol_x.cpu().numpy()
         del mask, vol_x
-        if self.device.type == 'cuda':
-            torch.cuda.empty_cache()
 
         self.cb, self._cb_inv = self._init_chequerboard()
-        # Preallocate hot-loop buffer (ImpedanceSolver sets field later)
-        if self.field is not None:
-            self.work = torch.empty(
-                (self.batch_size, self.Nx, self.Ny, self.Nz),
-                dtype=self.field.dtype,
-                device=self.device,
-            )
-        else:
-            self.work = None
 
         # Init params
         self.converged = False
@@ -113,7 +100,7 @@ class SORSolver(ABC):
     def init_reactive_neighbours(self, img: torch.Tensor) -> torch.Tensor:
         """S_i: amount of reactive neighbours (reac_nn)"""
         return None
-    
+
     def apply_boundary_conditions(self):
         """Default: Dirichlet in x and no-flux in y and z direction."""
 
@@ -125,15 +112,15 @@ class SORSolver(ABC):
         out.add_(self.field[:, 1:-1, 1:-1, 2:])
         out.add_(self.field[:, 1:-1, 1:-1, :-2])
 
-    def _apply_chequerboard(self, work: torch.Tensor) -> None:
+    def _apply_chequerboard(self, increment: torch.Tensor) -> None:
         """Zero the inactive colour and scale by omega, in-place."""
-        work.mul_(self.omega)
         mask_zero = self._cb_inv if (self.iter % 2 == 0) else self.cb
-        work.masked_fill_(mask_zero, 0)
-    
+        increment.masked_fill_(mask_zero, 0)
+        increment.mul_(self.omega)
+
     def plot_stats(self, relative_error):
         """Default: No plotting output."""
-    
+
     def check_convergence(self, verbose, conv_crit, plot_interval):
         self.tau, relative_error = self.compute_metrics()
 
@@ -141,7 +128,7 @@ class SORSolver(ABC):
             # Print stats for slowest converging microstructure
             i = np.argmax(relative_error)
             print(f'Iter: {self.iter}, conv error: {abs(relative_error[i]):.3E}, tau: {self.tau[i]:.5f} (batch element {i})')
-            
+
         if (verbose == 'plot') and (self.iter % (100*plot_interval) == 0):
             self.plot_stats(relative_error)
 
@@ -179,7 +166,7 @@ class SORSolver(ABC):
 
         self.tau[self.tau == 0] = np.inf
         return True
-    
+
     # ---------------- main loop -------------------
     def solve(self, iter_limit=10000, verbose=True, conv_crit=1e-2, plot_interval=10):
         """
@@ -198,14 +185,19 @@ class SORSolver(ABC):
             self.tau_t = []
 
         with torch.no_grad():
+            increment = torch.empty(
+                (self.batch_size, self.Nx, self.Ny, self.Nz),
+                dtype=self.field.dtype,
+                device=self.device,
+            )
             start = timer()
             while not self.converged and self.iter < iter_limit:
                 self.apply_boundary_conditions()
-                self.sum_weighted_neighbours(self.work)
-                self.work.div_(self.factor)
-                self.work.sub_(self.field[:, 1:-1, 1:-1, 1:-1])
-                self._apply_chequerboard(self.work)
-                self.field[:, 1:-1, 1:-1, 1:-1].add_(self.work)
+                self.sum_weighted_neighbours(increment)
+                increment /= self.factor
+                increment -= self.field[:, 1:-1, 1:-1, 1:-1]
+                self._apply_chequerboard(increment)
+                self.field[:, 1:-1, 1:-1, 1:-1] += increment
                 self.iter += 1
 
                 if self.iter % 100 == 0:
@@ -229,7 +221,7 @@ class SORSolver(ABC):
         if img.ndim != 4:
             raise ValueError("expected [B, X, Y, Z]")
         return img
-    
+
     @staticmethod
     def _init_device(device) -> torch.device:
         # check device is available
@@ -516,7 +508,7 @@ class AnisotropicSolver(Solver):
         nn[mask == 0] = torch.inf
         nn[nn == 0] = torch.inf
         return nn
-    
+
     def sum_weighted_neighbours(self, out):
         """Anisotropic 6-neighbor sum into a preallocated interior buffer."""
         torch.add(self.field[:, 2:, 1:-1, 1:-1], self.field[:, :-2, 1:-1, 1:-1], out=out)
@@ -650,7 +642,7 @@ class MultiPhaseSolver(ThroughTransportSolver):
         factor[:, -1] += self.D_x[:, -1, :, :]
         factor[factor == 0] = torch.inf
         return factor
-    
+
     def sum_weighted_neighbours(self, out) -> None:
         torch.mul(self.field[:, 2:, 1:-1, 1:-1], self.D_x[:, 1:, :, :], out=out)
         out.addcmul_(self.field[:, :-2, 1:-1, 1:-1], self.D_x[:, :-1, :, :])

--- a/tests/test_benchmark.py
+++ b/tests/test_benchmark.py
@@ -41,3 +41,5 @@ def test_run_benchmark_study_blocks_string_and_hook_match():
         write_file=False, devices=['cpu']
     )
     assert np.isclose(res1[0]["taufactor"], res2[0]["taufactor"])
+    for key in ("torch_init_max", "torch_init_cur", "torch_solve_max", "torch_solve_cur"):
+        assert res1[0][key] == 0.0


### PR DESCRIPTION
<html>
<body>
<!--StartFragment--><html><head></head><body><h2>Summary</h2><p>Reduces GPU memory use across TauFactor solvers while preserving benchmarked tortuosity values and convergence iteration counts.</p><ul><li>Stores segmentation labels as <code>uint8</code>; uses boolean checkerboards/masks.</li><li>Releases initialization temporaries earlier and avoids unnecessary full-volume field-profile <code>repeat()</code> allocations.</li><li>Reuses a solve-local increment buffer and accumulates neighbour sums in-place.</li><li>Replaces full-volume rolling neighbour sums with direct slice-based sums, including periodic Y/Z wrapping.</li><li>Extends benchmark output with separate initialization and solve RAM metrics: <code>VRAM_I_max</code>, <code>VRAM_I_cur</code>, <code>VRAM_S_max</code>, and <code>VRAM_S_cur</code>.</li></ul>

<h2>NVIDIA RTX A6000 benchmark</h2>
<p>Compared fcc structure runs up to 1024³ for current main versus this code, using <code>VRAM(max)</code> and solver wall time :</p>

Solver | Peak VRAM change | Solve-time change
-- | -- | --
Solver | −32.2% | +4.7%
PeriodicSolver | −32.1% | +4.6%
ElectrodeSolver | −21.5% | +4.7%
PeriodicElectrodeSolver | −21.4% | +4.6%

<p>Before these changes, initialization was particularly limiting for periodic solvers: periodic electrode initialization peaked at 424 MB versus 338 MB for the non-periodic version. Direct periodic neighbour sums remove that rolling-allocation bottleneck; both now peak at 287 MB during initialization. Overall peak memory is now determined by the solve phase rather than construction.</p>

Solver | Init peak reduction | Init current reduction
-- | -- | --
Solver | −19.9% | −28.3%
PeriodicSolver | −24.0% | −28.5%
ElectrodeSolver | −14.9% | −28.3%
PeriodicElectrodeSolver | −32.2% | −28.5%

<h2>Validation</h2><ul><li>Benchmark <code>tau</code> values and iteration counts are unchanged in the compared runs.</li><li>Focused solver and benchmark tests pass; lint and diff checks pass.</li></ul>
</body>
</html><!--EndFragment-->
</body>
</html>